### PR TITLE
Upgraded version of golangci-lint-action to @2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v1
+      uses: golangci/golangci-lint-action@v2
       with:
         # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
         version: v1.28


### PR DESCRIPTION
Hi, @schachmat, @kordianbruck!

Currently workflow checks are failing for https://github.com/google/go-patchutils/pull/14. It needs upgrade of golangci-lint-action version.